### PR TITLE
ommit cells starting with ! %% and %

### DIFF
--- a/notebook/example flake8_magic.ipynb
+++ b/notebook/example flake8_magic.ipynb
@@ -407,9 +407,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebook/example pycodestyle_magic.ipynb
+++ b/notebook/example pycodestyle_magic.ipynb
@@ -13,19 +13,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "3:2: E225 missing whitespace around operator\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle\n",
-    "# BAD\n",
-    "a=1"
+    "%pycodestyle_on "
    ]
   },
   {
@@ -37,12 +27,29 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "4:4: E111 indentation is not a multiple of four\n"
+      "2:2: E225 missing whitespace around operator\n"
      ]
     }
    ],
    "source": [
-    "%%pycodestyle\n",
+    "# BAD\n",
+    "a=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "3:4: E111 indentation is not a multiple of four\n"
+     ]
+    }
+   ],
+   "source": [
     "# BAD\n",
     "if True:\n",
     "   n_space = 3"
@@ -50,11 +57,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# GOOD\n",
     "if True:\n",
     "    n_space = 4"
@@ -62,54 +68,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "5:5: E128 continuation line under-indented for visual indent\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%pycodestyle\n",
-    "# BAD\n",
-    "# Aligned with 4 spaces\n",
-    "foo = function(var_one, var_two,\n",
-    "    var_three, var_four)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%pycodestyle\n",
-    "# GOOD\n",
-    "# Aligned with opening parenthesis\n",
-    "foo = function(var_one, var_two,\n",
-    "               var_three, var_four)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "7:1: E731 do not assign a lambda expression, use a def\n",
-      "7:80: E501 line too long (118 > 79 characters)\n"
+      "6:1: E731 do not assign a lambda expression, use a def\n",
+      "6:80: E501 line too long (118 > 79 characters)\n"
      ]
     }
    ],
    "source": [
-    "%%pycodestyle\n",
     "# BAD\n",
     "# longer than 79 characters\n",
     "# possible divison error\n",
@@ -120,11 +91,54 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pycodestyle_off"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
+    "# BAD\n",
+    "if True:\n",
+    "   n_space = 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# BAD\n",
+    "# Aligned with 4 spaces\n",
+    "foo = function(var_one, var_two,\n",
+    "    var_three, var_four)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GOOD\n",
+    "# Aligned with opening parenthesis\n",
+    "foo = function(var_one, var_two,\n",
+    "               var_three, var_four)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# GOOD\n",
     "# Shorter than 79\n",
     "# Use scipy, numpy\n",
@@ -143,20 +157,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "4:1: E302 expected 2 blank lines, found 0\n",
-      "7:5: E301 expected 1 blank line, found 0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# BAD\n",
     "import numpy as np\n",
     "class Calculator:\n",
@@ -168,11 +172,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# GOOD\n",
     "import numpy as np\n",
     "\n",
@@ -187,30 +190,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "3:13: E401 multiple imports on one line\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# BAD\n",
     "import numpy, scipy, io, os"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# GOOD\n",
     "# python packages first\n",
     "import os\n",
@@ -225,11 +218,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# GOOD\n",
     "from ctypes import (c_void_p, c_int,\n",
     "                    c_double, c_char_p,\n",
@@ -238,22 +230,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "3:2: E225 missing whitespace around operator\n",
-      "4:4: E111 indentation is not a multiple of four\n",
-      "4:4: E113 unexpected indentation\n",
-      "5:4: E111 indentation is not a multiple of four\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle \n",
     "# BAD\n",
     "a=x+1\n",
     "   a = x + 1\n",
@@ -263,11 +243,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle \n",
     "# GOOD\n",
     "a = x + 1\n",
     "a = x + 1\n",
@@ -277,25 +256,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "3:1: E302 expected 2 blank lines, found 0\n",
-      "3:23: E251 unexpected spaces around keyword / parameter equals\n",
-      "3:25: E251 unexpected spaces around keyword / parameter equals\n",
-      "4:19: E251 unexpected spaces around keyword / parameter equals\n",
-      "4:21: E251 unexpected spaces around keyword / parameter equals\n",
-      "4:29: E251 unexpected spaces around keyword / parameter equals\n",
-      "4:31: E251 unexpected spaces around keyword / parameter equals\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle \n",
     "# BAD\n",
     "def complex(real, imag = 0.0):\n",
     "    return magic(r = real, i = imag)"
@@ -303,11 +267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "\n",
     "\n",
     "# GOOD\n",
@@ -317,20 +280,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "4:7: E702 multiple statements on one line (semicolon)\n",
-      "4:15: E702 multiple statements on one line (semicolon)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle \n",
     "# BAD\n",
     "a, b, c = 0, 0, 0\n",
     "a += 1; b += 2; c += 3"
@@ -338,11 +291,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# GOOD\n",
     "a = b = c = 0\n",
     "a += 1\n",
@@ -352,19 +304,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "3:1: E302 expected 2 blank lines, found 0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "# BAD\n",
     "def jarekenmaar():\n",
     "    # This comment is in Dutch\n",
@@ -375,11 +318,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%pycodestyle\n",
     "\n",
     "\n",
     "# GOOD\n",
@@ -413,9 +355,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/pycodestyle_magic.py
+++ b/pycodestyle_magic.py
@@ -5,7 +5,7 @@ a=1
 should give an error about missing spaces
 """
 
-__version__ = '0.3'
+__version__ = '0.4'
 
 import sys
 import tempfile
@@ -105,6 +105,8 @@ def pycodestyle(line, cell, auto=False):
     # temporary replace
     sys.stdout = io.StringIO()
     # store code in a file, todo unicode
+    if cell.startswith(('!', '%%', '%')):
+        return    
     with tempfile.NamedTemporaryFile(mode='r+',delete=False) as f:
         # save to file
         f.write('# The %%pycodestyle cell magic was here\n' + cell + '\n')
@@ -147,6 +149,8 @@ def flake8(line, cell, auto=False):
         return
 
     logger.setLevel(logging.INFO)
+    if cell.startswith(('!', '%%', '%')):
+        return
     with tempfile.NamedTemporaryFile(mode='r+', delete=False) as f:
         # save to file
         f.write(cell)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit.buildapi"
 [tool.flit.metadata]
 module = "pycodestyle_magic"
 author = "Mattijn van Hoek"
-author-email = "hoek@hkv.nl"
+author-email = "mattijn@gmail.com"
 home-page = "https://github.com/mattijn/pycodestyle_magic"
 classifiers = ["License :: OSI Approved :: MIT License"]
 


### PR DESCRIPTION
It should now be possible to use all magic functions (starting with `!`, `&&` or `%`) without being checked by `flake8` or `pycodestyle`

<img width="580" alt="image" src="https://user-images.githubusercontent.com/5186265/65637869-30c17380-dfe5-11e9-9259-c580b69e4d20.png">
