### PR TITLE
add-options for flake8_on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 *.tar.gz
-
-# Jupyter Notebook
 .ipynb_checkpoints
 *.ipynb
+.DS_Store
+.pytest_cache/*
+dist/*
+dist


### PR DESCRIPTION
This PR adds two options for the `%flake8_on` magic.

1. The option `--ignore` or `-i` will add the the named error(s) to the ignore list

Example to ignore the errors `E225` and `E265`:
```
%flake8_on --ignore E225,E265
``` 
Remember to _avoid_ spaces between declaring multiple errors.

2. With the option `--max_line_length` or `-m` the max-line-length can be customised.

Example set the line length to `119` characters instead of the default `79`:
```
%flake8_on --max_line_length 119
```

The options can be combined as well. 
